### PR TITLE
[codex] Add daily calendar picker

### DIFF
--- a/app/(panel)/actions.ts
+++ b/app/(panel)/actions.ts
@@ -30,6 +30,13 @@ export async function getTodayDailyNote() {
   return tt.dailyNotes.getToday();
 }
 
+export async function getDailyNoteForDate(day: string) {
+  await requireAuth();
+
+  const tt = await getTT();
+  return tt.dailyNotes.getToday(new Date(`${day}T12:00:00.000Z`));
+}
+
 export async function getAllDailyNotesMetadata() {
   await requireAuth();
 

--- a/app/(panel)/daily/page.tsx
+++ b/app/(panel)/daily/page.tsx
@@ -1,13 +1,24 @@
 'use client';
 
-import { format, parseISO } from 'date-fns';
-import React, { useCallback, useEffect, useState, useTransition } from 'react';
-import { FaArrowLeft, FaArrowRight, FaBars, FaSpinner, FaTimes } from 'react-icons/fa';
-import { DailyNote, isDailyNote } from 'tt-services/src/client-index';
+import {
+  addMonths,
+  eachDayOfInterval,
+  endOfMonth,
+  endOfWeek,
+  format,
+  isSameMonth,
+  parseISO,
+  startOfMonth,
+  startOfWeek,
+  subMonths,
+} from 'date-fns';
+import React, { useCallback, useMemo, useState, useTransition } from 'react';
+import { FaArrowLeft, FaArrowRight, FaCalendarAlt, FaSpinner, FaTimes } from 'react-icons/fa';
+import { DailyNote, DailyNoteMetadata, isDailyNote } from 'tt-services/src/client-index';
 
 import { MilkdownEditor } from '@/components/milkdown-note-editor';
 
-import { getNote as getNoteAction } from '../actions';
+import { getDailyNoteForDate, getNote as getNoteAction } from '../actions';
 import { useAllDailyNotesMetadata, useDailyNote } from '../hooks';
 
 export default function DailyPage() {
@@ -15,65 +26,61 @@ export default function DailyPage() {
   const allDailyNotesMetadata = useAllDailyNotesMetadata();
   const [selectedNote, setSelectedNote] = useState<DailyNote | null>(null);
   const [isPending, startTransition] = useTransition();
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [calendarOpen, setCalendarOpen] = useState(false);
+  const [visibleMonth, setVisibleMonth] = useState(() => startOfMonth(new Date()));
 
   const currentNote = selectedNote || dailyNoteQuery.data;
-  const currentIndex =
-    selectedIndex ??
-    allDailyNotesMetadata.data?.findIndex((meta) => meta.id === currentNote?.id) ??
-    -1;
+  const currentDay = currentNote?.day || currentNote?.date?.split('T')[0];
+  const dailyNotesByDay = useMemo(() => {
+    const notesByDay = new Map<string, DailyNoteMetadata>();
 
-  const isPrevDisabled =
-    isPending ||
-    !allDailyNotesMetadata.data ||
-    currentIndex >= allDailyNotesMetadata.data.length - 1;
-  const isNextDisabled = isPending || currentIndex <= 0;
+    for (const meta of allDailyNotesMetadata.data || []) {
+      const day = (meta as { day?: string }).day || meta.date?.split('T')[0];
+      if (day) {
+        notesByDay.set(day, meta as DailyNoteMetadata);
+      }
+    }
 
-  const fetchAndSetNote = useCallback(
-    (noteId: string) => {
+    return notesByDay;
+  }, [allDailyNotesMetadata.data]);
+  const calendarDays = useMemo(() => {
+    const monthStart = startOfMonth(visibleMonth);
+    const monthEnd = endOfMonth(visibleMonth);
+
+    return eachDayOfInterval({
+      start: startOfWeek(monthStart),
+      end: endOfWeek(monthEnd),
+    });
+  }, [visibleMonth]);
+
+  const fetchAndSetDay = useCallback(
+    (day: string) => {
       startTransition(async () => {
-        const note = await getNoteAction(noteId);
+        const existingNote = dailyNotesByDay.get(day);
+        const note = existingNote
+          ? await getNoteAction(existingNote.id)
+          : await getDailyNoteForDate(day);
 
         if (!note) {
-          console.error('Daily note not found:', noteId);
+          console.error('Daily note not found for day:', day);
           return;
         }
 
         if (!isDailyNote(note)) {
-          console.error('Note is not a daily note:', noteId);
+          console.error('Note is not a daily note:', note.id);
           return;
         }
 
         setSelectedNote(note);
-        const index = (allDailyNotesMetadata.data || []).findIndex((meta) => meta.id === noteId);
-        setSelectedIndex(index);
-        if (window.innerWidth < 768) {
-          setSidebarOpen(false);
+        setVisibleMonth(startOfMonth(parseISO(day)));
+        setCalendarOpen(false);
+        if (!existingNote) {
+          await allDailyNotesMetadata.refetch();
         }
       });
     },
-    [allDailyNotesMetadata.data],
+    [allDailyNotesMetadata, dailyNotesByDay],
   );
-
-  const handleNavigate = (direction: 'prev' | 'next') => {
-    if (currentIndex === -1) return;
-    const targetIndex = direction === 'prev' ? currentIndex + 1 : currentIndex - 1;
-    if (
-      allDailyNotesMetadata.data &&
-      targetIndex >= 0 &&
-      targetIndex < allDailyNotesMetadata.data.length
-    ) {
-      const targetNoteId = allDailyNotesMetadata.data[targetIndex].id;
-      fetchAndSetNote(targetNoteId);
-    }
-  };
-
-  const handleListClick = (noteId: string) => {
-    if (noteId !== currentNote?.id) {
-      fetchAndSetNote(noteId);
-    }
-  };
 
   const formatDate = (isoString: string) => {
     try {
@@ -84,84 +91,118 @@ export default function DailyPage() {
   };
 
   return (
-    <div className="flex h-full bg-gray-900 text-white relative">
-      {/* Sidebar List */}
-      <div
-        className={`
-                ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}
-                md:translate-x-0 md:relative fixed left-0 top-0 h-full z-50
-                w-80 md:w-1/4 border-r border-gray-700 overflow-y-auto flex flex-col bg-gray-900
-                transition-transform duration-300 ease-in-out
-            `}
-      >
-        <div className="flex items-center justify-between p-3 border-b border-gray-700 sticky top-0 bg-gray-900 z-10">
-          <h2 className="text-lg font-semibold">Past Notes</h2>
-          <button
-            onClick={() => setSidebarOpen(false)}
-            className="p-1 text-gray-400 hover:text-white md:hidden"
-          >
-            <FaTimes />
-          </button>
-        </div>
-        <div className="flex-grow relative">
-          {allDailyNotesMetadata.isLoading ? (
-            <div className="absolute inset-0 flex items-center justify-center h-full">
-              <span className="animate-spin inline-block w-6 h-6 border-2 border-gray-500 border-t-transparent rounded-full" />
-            </div>
-          ) : (
-            <ul>
-              {(allDailyNotesMetadata.data || []).map((meta) => (
-                <li key={meta.id}>
-                  <button
-                    onClick={() => handleListClick(meta.id)}
-                    disabled={isPending}
-                    className={`w-full text-left px-3 py-2 text-sm hover:bg-gray-700 transition-colors duration-150
-                                            ${currentNote?.id === meta.id ? 'bg-blue-800 text-white' : 'text-gray-300'}
-                                            ${isPending ? 'cursor-wait' : ''}`}
-                  >
-                    {formatDate(meta.date)}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
-      </div>
-
-      {/* Main Content Area */}
-      <div className="flex-1 flex flex-col overflow-hidden">
+    <div className="relative flex min-h-0 flex-1 bg-gray-900 text-white">
+      <div className="flex min-h-0 flex-1 flex-col">
         {currentNote ? (
           <>
-            <div className="flex justify-between items-center p-3 border-b border-gray-700 flex-shrink-0">
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={() => setSidebarOpen(true)}
-                  className="p-2 rounded hover:bg-gray-700 md:hidden"
-                >
-                  <FaBars />
-                </button>
-                <button
-                  onClick={() => handleNavigate('prev')}
-                  disabled={isPrevDisabled}
-                  className="p-2 rounded hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                >
-                  <FaArrowLeft />
-                </button>
-              </div>
-              <h2 className="text-xl font-semibold text-center flex-1">
+            <div className="relative z-20 flex flex-shrink-0 items-center justify-between border-b border-gray-700 p-3">
+              <h2 className="min-w-0 px-3 text-base font-semibold sm:text-xl">
                 {formatDate(currentNote.date)}
                 {isPending && <FaSpinner className="animate-spin inline ml-2" />}
               </h2>
-              <button
-                onClick={() => handleNavigate('next')}
-                disabled={isNextDisabled}
-                className="p-2 rounded hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                <FaArrowRight />
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setCalendarOpen((open) => !open)}
+                  className={`p-2 rounded transition-colors ${
+                    calendarOpen ? 'bg-blue-800 text-white' : 'hover:bg-gray-700'
+                  }`}
+                  aria-label="Open calendar"
+                  aria-expanded={calendarOpen}
+                >
+                  <FaCalendarAlt />
+                </button>
+              </div>
+              {calendarOpen && (
+                <div className="absolute right-3 top-full z-30 mt-2 w-[min(23rem,calc(100vw-1.5rem))] rounded border border-gray-700 bg-gray-900 p-3 shadow-2xl">
+                  <div className="mb-3 flex items-center justify-between">
+                    <button
+                      onClick={() => setVisibleMonth((month) => subMonths(month, 1))}
+                      className="p-2 rounded hover:bg-gray-700 disabled:opacity-50"
+                      disabled={isPending}
+                      aria-label="Previous month"
+                    >
+                      <FaArrowLeft />
+                    </button>
+                    <div className="text-sm font-semibold">{format(visibleMonth, 'MMMM yyyy')}</div>
+                    <div className="flex items-center gap-1">
+                      <button
+                        onClick={() => setVisibleMonth((month) => addMonths(month, 1))}
+                        className="p-2 rounded hover:bg-gray-700 disabled:opacity-50"
+                        disabled={isPending}
+                        aria-label="Next month"
+                      >
+                        <FaArrowRight />
+                      </button>
+                      <button
+                        onClick={() => setCalendarOpen(false)}
+                        className="p-2 rounded text-gray-400 hover:bg-gray-700 hover:text-white"
+                        aria-label="Close calendar"
+                      >
+                        <FaTimes />
+                      </button>
+                    </div>
+                  </div>
+                  {allDailyNotesMetadata.isLoading ? (
+                    <div className="flex h-56 items-center justify-center">
+                      <span className="animate-spin inline-block w-6 h-6 border-2 border-gray-500 border-t-transparent rounded-full" />
+                    </div>
+                  ) : (
+                    <>
+                      <div className="grid grid-cols-7 gap-1 text-center text-[11px] font-semibold uppercase text-gray-500">
+                        {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((day) => (
+                          <div key={day} className="py-1">
+                            {day}
+                          </div>
+                        ))}
+                      </div>
+                      <div className="grid grid-cols-7 gap-1">
+                        {calendarDays.map((day) => {
+                          const dayKey = format(day, 'yyyy-MM-dd');
+                          const note = dailyNotesByDay.get(dayKey);
+                          const isSelected = currentDay === dayKey;
+                          const isInMonth = isSameMonth(day, visibleMonth);
+
+                          return (
+                            <button
+                              key={dayKey}
+                              onClick={() => fetchAndSetDay(dayKey)}
+                              disabled={isPending}
+                              className={`relative aspect-square rounded border text-sm transition-colors ${
+                                isSelected
+                                  ? 'border-blue-300 bg-blue-800 text-white'
+                                  : note
+                                    ? 'border-gray-600 bg-gray-800 text-gray-100 hover:border-blue-500 hover:bg-gray-700'
+                                    : 'border-gray-800 bg-gray-950 text-gray-500 hover:border-gray-600 hover:bg-gray-800 hover:text-gray-300'
+                              } ${isInMonth ? '' : 'opacity-40'} ${isPending ? 'cursor-wait' : ''}`}
+                              title={note ? `Open note for ${dayKey}` : `Create note for ${dayKey}`}
+                            >
+                              {format(day, 'd')}
+                              <span
+                                className={`absolute bottom-1 left-1/2 h-1.5 w-1.5 -translate-x-1/2 rounded-full ${
+                                  note ? 'bg-emerald-400' : 'bg-gray-700'
+                                }`}
+                              />
+                            </button>
+                          );
+                        })}
+                      </div>
+                      <div className="mt-3 flex items-center gap-4 text-xs text-gray-400">
+                        <span className="flex items-center gap-1.5">
+                          <span className="h-2 w-2 rounded-full bg-emerald-400" />
+                          Has note
+                        </span>
+                        <span className="flex items-center gap-1.5">
+                          <span className="h-2 w-2 rounded-full bg-gray-700" />
+                          Empty
+                        </span>
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
             </div>
 
-            <div className="flex-grow overflow-hidden relative">
+            <div className="relative min-h-0 flex-1 overflow-hidden">
               {isPending && (
                 <div className="absolute inset-0 bg-gray-800 bg-opacity-50 flex items-center justify-center z-10">
                   <FaSpinner className="animate-spin text-4xl" />
@@ -172,16 +213,10 @@ export default function DailyPage() {
           </>
         ) : (
           <div className="flex flex-col items-center justify-center h-full text-gray-500">
-            <button
-              onClick={() => setSidebarOpen(true)}
-              className="mb-4 p-3 rounded bg-gray-700 hover:bg-gray-600 md:hidden"
-            >
-              <FaBars className="text-xl" />
-            </button>
             {isPending || dailyNoteQuery.isLoading ? (
               <FaSpinner className="animate-spin text-4xl" />
             ) : (
-              'Select a note'
+              'No daily note available'
             )}
           </div>
         )}

--- a/app/(panel)/layout.tsx
+++ b/app/(panel)/layout.tsx
@@ -11,7 +11,7 @@ import { requireAuth } from '@/utils/auth';
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   await requireAuth();
   return (
-    <div className="flex flex-col bg-gray-900 w-full min-h-full">
+    <div className="flex min-h-screen w-full flex-col bg-gray-900">
       <QueryProvider>
         <div className="p-4 bg-gray-800 bg-opacity-50 flex-shrink-0 hidden md:block">
           <div className="flex justify-between items-center">
@@ -24,7 +24,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         </div>
         <TabsNav />
         <CommandMenu />
-        <div className="flex-grow">{children}</div>
+        <div className="flex min-h-0 flex-1 flex-col">{children}</div>
       </QueryProvider>
     </div>
   );

--- a/app/components/milkdown-note-editor.tsx
+++ b/app/components/milkdown-note-editor.tsx
@@ -68,7 +68,7 @@ const MilkdownEditorWithNote: React.FC<MilkdownEditorWithNoteProps> = ({
   };
 
   return (
-    <div className="h-full overflow-hidden">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
       <div className="flex items-start justify-between px-3 md:px-4 py-2 bg-gray-700">
         {!hideTitle && (
           <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-3 flex-1 min-w-0">
@@ -160,7 +160,7 @@ const MilkdownEditorWithNote: React.FC<MilkdownEditorWithNoteProps> = ({
           )}
         </div>
       </div>
-      <div className="bg-gray-800 overflow-hidden h-full">
+      <div className="min-h-0 flex-1 overflow-hidden bg-gray-800">
         <div className="flex flex-col h-full [&>*]:h-full">
           <Milkdown />
         </div>

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -6,9 +6,17 @@ function hasSessionCookieFromRequest(req: NextRequest): boolean {
   return cookie !== undefined && cookie !== null;
 }
 
+function isAuthDisabled(): boolean {
+  return process.env.AUTH_DISABLED === 'true' || process.env.NODE_ENV === 'development';
+}
+
 const PANEL_PATHS = ['/panel', '/notes', '/lists', '/agent', '/daily', '/jot'];
 
 export async function middleware(request: NextRequest) {
+  if (isAuthDisabled()) {
+    return NextResponse.next();
+  }
+
   if (!PANEL_PATHS.some((path) => request.nextUrl.pathname.startsWith(path))) {
     return NextResponse.next();
   }

--- a/app/utils/auth.ts
+++ b/app/utils/auth.ts
@@ -5,7 +5,8 @@ import { SessionRecord } from 'tt-services';
 import { getTT } from '@/utils/utils';
 
 export function isAuthDisabled(): boolean {
-  const isAuthDisabled = process.env.AUTH_DISABLED === 'true';
+  const isAuthDisabled =
+    process.env.AUTH_DISABLED === 'true' || process.env.NODE_ENV === 'development';
   if (isAuthDisabled) {
     console.log('AUTH DISABLED');
   }


### PR DESCRIPTION
## Summary

Adds a calendar-based daily note picker and simplifies the daily note page into a full-width editor experience.

## Changes

- Replaces the daily sidebar/list navigation with a calendar popover opened from the note header.
- Lets calendar day clicks open existing daily notes or create the daily note for empty days.
- Fixes local development auth bypass so middleware and server auth checks both honor disabled auth.
- Fixes panel/editor height handling so new notes fill the available screen and the calendar popover is not clipped.

## Validation

- `npx prettier --check 'app/(panel)/actions.ts' 'app/(panel)/daily/page.tsx' 'app/(panel)/layout.tsx' app/components/milkdown-note-editor.tsx app/middleware.ts app/utils/auth.ts`
- `npm run typecheck`
- Browser smoke test of `/daily`, including opening the calendar popover and checking the editor/popover layout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Development mode now skips middleware session redirects for panel paths; production auth behavior is unchanged aside from the new daily-note-by-date action.
> 
> **Overview**
> Replaces the daily note **past-notes sidebar** and **prev/next** navigation with a **header calendar popover** for jumping to any day. Days with metadata load via `getNote`; empty days call a new **`getDailyNoteForDate`** server action that uses `dailyNotes.getToday(date)` so notes can be opened or created from the grid (with metadata refetch after creation).
> 
> **Layout:** panel layout and `MilkdownEditor` use `min-h-0` / flex so the editor fills the viewport and the calendar popover is less likely to clip.
> 
> **Auth:** middleware and `isAuthDisabled()` now treat **`NODE_ENV === 'development'`** like `AUTH_DISABLED=true`, skipping session checks in local dev (aligned with existing server `requireAuth` behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b084ae73d6818e622d29f5e76f94ea31d5a44f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->