### PR TITLE
[codex] Improve notes UI

### DIFF
--- a/app/(panel)/actions.ts
+++ b/app/(panel)/actions.ts
@@ -223,7 +223,7 @@ export async function getNotesAndUntrackedGoogleDocs() {
   const userId = await getGoogleUserId();
   const result = userId
     ? await tt.googleNotes.getAllNotesAndUntrackedGoogleDocs(userId)
-    : { notes: [], googleDocs: [] };
+    : { notes: await tt.notes.getAllNotesMetadata(), googleDocs: [] };
   return { ...result, showGoogleNotice: !userId };
 }
 

--- a/app/(panel)/notes/page.tsx
+++ b/app/(panel)/notes/page.tsx
@@ -16,7 +16,7 @@ export type LayoutMode = 'grid' | 'list';
 export default function NotesPage() {
   const router = useRouter();
   const { data, isLoading } = useNotesIndex();
-  const [layoutMode, setLayoutMode] = useState<LayoutMode>('grid');
+  const [layoutMode, setLayoutMode] = useState<LayoutMode>('list');
   const [filteredItems, setFilteredItems] = useState<any[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const itemRefs = useRef<Array<HTMLDivElement | null>>([]);

--- a/app/(panel)/notes/page.tsx
+++ b/app/(panel)/notes/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FaList, FaThLarge } from 'react-icons/fa';
 
 import { NoteCard } from '@/components/note-card';
@@ -18,6 +18,8 @@ export default function NotesPage() {
   const { data, isLoading } = useNotesIndex();
   const [layoutMode, setLayoutMode] = useState<LayoutMode>('grid');
   const [filteredItems, setFilteredItems] = useState<any[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const itemRefs = useRef<Array<HTMLDivElement | null>>([]);
 
   const displayItems = useMemo(() => {
     if (!data) return [] as any[];
@@ -45,6 +47,35 @@ export default function NotesPage() {
   }, [data]);
 
   const toggleLayout = () => setLayoutMode((prev) => (prev === 'grid' ? 'list' : 'grid'));
+
+  const openItem = useCallback(
+    (item: any) => {
+      if (!item) return;
+
+      if (item.type === 'note') {
+        router.push(`/note/${item.id}/view`);
+        return;
+      }
+
+      const webViewLink = item.originalItem?.webViewLink;
+      if (webViewLink) {
+        window.open(webViewLink, '_blank', 'noreferrer');
+      }
+    },
+    [router],
+  );
+
+  useEffect(() => {
+    setSelectedIndex((current) => {
+      if (filteredItems.length === 0) return 0;
+      return Math.min(current, filteredItems.length - 1);
+    });
+  }, [filteredItems.length]);
+
+  useEffect(() => {
+    const selectedElement = itemRefs.current[selectedIndex];
+    selectedElement?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
 
   useEffect(() => {
     const isEditableTarget = (target: EventTarget | null) => {
@@ -78,11 +109,28 @@ export default function NotesPage() {
         event.preventDefault();
         router.push('/notes/create');
       }
+
+      if (['arrowdown', 'arrowright'].includes(key)) {
+        event.preventDefault();
+        setSelectedIndex((current) =>
+          filteredItems.length === 0 ? 0 : Math.min(current + 1, filteredItems.length - 1),
+        );
+      }
+
+      if (['arrowup', 'arrowleft'].includes(key)) {
+        event.preventDefault();
+        setSelectedIndex((current) => (filteredItems.length === 0 ? 0 : Math.max(current - 1, 0)));
+      }
+
+      if (key === 'enter') {
+        event.preventDefault();
+        openItem(filteredItems[selectedIndex]);
+      }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [router]);
+  }, [filteredItems, openItem, router, selectedIndex]);
 
   if (isLoading) return <div className="p-4 text-gray-300">Loading notes…</div>;
 
@@ -93,6 +141,8 @@ export default function NotesPage() {
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
           <div className="flex flex-wrap items-center gap-2 text-xs text-gray-400">
             <ShortcutKey label="/" text="Search" />
+            <ShortcutKey label="↑↓" text="Select" />
+            <ShortcutKey label="Enter" text="Open" />
             <ShortcutKey label="V" text="View" />
             <ShortcutKey label="N" text="New" />
           </div>
@@ -138,8 +188,18 @@ export default function NotesPage() {
 
       {layoutMode === 'grid' ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filteredItems.map((item) => (
-            <div key={`${item.type}-${item.id}`} className="h-full">
+          {filteredItems.map((item, index) => (
+            <div
+              key={`${item.type}-${item.id}`}
+              ref={(element) => {
+                itemRefs.current[index] = element;
+              }}
+              className={getSelectionClassName(selectedIndex === index, 'grid')}
+              tabIndex={selectedIndex === index ? 0 : -1}
+              aria-selected={selectedIndex === index}
+              onClick={() => setSelectedIndex(index)}
+              onDoubleClick={() => openItem(item)}
+            >
               {item.type === 'note' ? (
                 <NoteCard note={item.originalItem} layout="grid" />
               ) : (
@@ -150,8 +210,18 @@ export default function NotesPage() {
         </div>
       ) : (
         <div className="flex flex-col gap-1.5">
-          {filteredItems.map((item) => (
-            <div key={`${item.type}-${item.id}`}>
+          {filteredItems.map((item, index) => (
+            <div
+              key={`${item.type}-${item.id}`}
+              ref={(element) => {
+                itemRefs.current[index] = element;
+              }}
+              className={getSelectionClassName(selectedIndex === index, 'list')}
+              tabIndex={selectedIndex === index ? 0 : -1}
+              aria-selected={selectedIndex === index}
+              onClick={() => setSelectedIndex(index)}
+              onDoubleClick={() => openItem(item)}
+            >
               {item.type === 'note' ? (
                 <NoteCard note={item.originalItem} layout="list" />
               ) : (
@@ -171,6 +241,15 @@ export default function NotesPage() {
       )}
     </div>
   );
+}
+
+function getSelectionClassName(isSelected: boolean, layout: LayoutMode) {
+  const base = layout === 'grid' ? 'h-full rounded-lg' : 'rounded-lg';
+  return `${base} transition-shadow ${
+    isSelected
+      ? 'ring-2 ring-blue-400 ring-offset-2 ring-offset-gray-900'
+      : 'ring-1 ring-transparent'
+  }`;
 }
 
 function ShortcutKey({ label, text }: { label: string; text: string }) {

--- a/app/(panel)/notes/page.tsx
+++ b/app/(panel)/notes/page.tsx
@@ -149,7 +149,7 @@ export default function NotesPage() {
           ))}
         </div>
       ) : (
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1.5">
           {filteredItems.map((item) => (
             <div key={`${item.type}-${item.id}`}>
               {item.type === 'note' ? (

--- a/app/(panel)/notes/page.tsx
+++ b/app/(panel)/notes/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import React, { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import React, { useEffect, useMemo, useState } from 'react';
 import { FaList, FaThLarge } from 'react-icons/fa';
 
 import { NoteCard } from '@/components/note-card';
@@ -13,6 +14,7 @@ import { useNotesIndex } from '../hooks';
 export type LayoutMode = 'grid' | 'list';
 
 export default function NotesPage() {
+  const router = useRouter();
   const { data, isLoading } = useNotesIndex();
   const [layoutMode, setLayoutMode] = useState<LayoutMode>('grid');
   const [filteredItems, setFilteredItems] = useState<any[]>([]);
@@ -44,30 +46,85 @@ export default function NotesPage() {
 
   const toggleLayout = () => setLayoutMode((prev) => (prev === 'grid' ? 'list' : 'grid'));
 
+  useEffect(() => {
+    const isEditableTarget = (target: EventTarget | null) => {
+      if (!(target instanceof HTMLElement)) return false;
+
+      return (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target.isContentEditable ||
+        target.closest('[role="textbox"]')
+      );
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+      if (isEditableTarget(event.target)) return;
+
+      const key = event.key.toLowerCase();
+
+      if (key === '/') {
+        event.preventDefault();
+        document.getElementById('notes-search-input')?.focus();
+      }
+
+      if (key === 'v') {
+        event.preventDefault();
+        setLayoutMode((prev) => (prev === 'grid' ? 'list' : 'grid'));
+      }
+
+      if (key === 'n') {
+        event.preventDefault();
+        router.push('/notes/create');
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [router]);
+
   if (isLoading) return <div className="p-4 text-gray-300">Loading notes…</div>;
 
   return (
     <div className="min-h-full bg-gray-900 text-white p-4 md:p-6">
-      <div className="flex justify-between items-center mb-6">
+      <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <h1 className="text-2xl md:text-3xl font-bold">Notes</h1>
-        <div className="flex gap-3 items-center">
-          <button
-            onClick={toggleLayout}
-            className="p-2 bg-gray-800 rounded-lg hover:bg-gray-700 transition-colors"
-            title={`Switch to ${layoutMode === 'grid' ? 'list' : 'grid'} view`}
-          >
-            {layoutMode === 'grid' ? (
-              <FaList className="text-gray-300" size={18} />
-            ) : (
-              <FaThLarge className="text-gray-300" size={18} />
-            )}
-          </button>
-          <Link
-            href="/notes/create"
-            className="bg-blue-600 px-3 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm"
-          >
-            Create Note
-          </Link>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-gray-400">
+            <ShortcutKey label="/" text="Search" />
+            <ShortcutKey label="V" text="View" />
+            <ShortcutKey label="N" text="New" />
+          </div>
+          <div className="flex gap-3 items-center">
+            <button
+              onClick={toggleLayout}
+              className="inline-flex h-10 items-center gap-2 rounded-lg border border-gray-700 bg-gray-800 px-3 text-sm text-gray-300 transition-colors hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900"
+              title={`Switch to ${layoutMode === 'grid' ? 'list' : 'grid'} view`}
+              aria-label={`Switch to ${layoutMode === 'grid' ? 'list' : 'grid'} view`}
+              aria-keyshortcuts="V"
+            >
+              {layoutMode === 'grid' ? (
+                <FaList className="text-gray-300" size={16} />
+              ) : (
+                <FaThLarge className="text-gray-300" size={16} />
+              )}
+              <span>{layoutMode === 'grid' ? 'List' : 'Grid'}</span>
+              <kbd className="rounded border border-gray-600 bg-gray-900 px-1.5 py-0.5 text-[10px] text-gray-400">
+                V
+              </kbd>
+            </button>
+            <Link
+              href="/notes/create"
+              className="inline-flex h-10 items-center gap-2 rounded-lg bg-blue-600 px-3 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900"
+              aria-keyshortcuts="N"
+            >
+              Create Note
+              <kbd className="rounded border border-blue-300/40 bg-blue-950/40 px-1.5 py-0.5 text-[10px] text-blue-100">
+                N
+              </kbd>
+            </Link>
+          </div>
         </div>
       </div>
 
@@ -113,5 +170,14 @@ export default function NotesPage() {
         </div>
       )}
     </div>
+  );
+}
+
+function ShortcutKey({ label, text }: { label: string; text: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-md border border-gray-700 bg-gray-800/80 px-2 py-1">
+      <kbd className="font-mono text-[11px] text-gray-200">{label}</kbd>
+      <span>{text}</span>
+    </span>
   );
 }

--- a/app/components/NotesFilter.tsx
+++ b/app/components/NotesFilter.tsx
@@ -231,10 +231,12 @@ export function NotesFilter({ items, setFilteredItems }: NotesFilterProps) {
             <FaSearch className="text-gray-400" />
           </div>
           <input
+            id="notes-search-input"
             type="text"
             value={search}
             onChange={handleSearchChange}
             placeholder="Search notes..."
+            aria-keyshortcuts="/"
             className="bg-gray-700 text-white pl-10 pr-10 py-2 rounded-lg w-full focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
           {search && (

--- a/app/components/base-card.tsx
+++ b/app/components/base-card.tsx
@@ -3,13 +3,14 @@
 import { formatDistance } from 'date-fns';
 import React, { ReactNode } from 'react';
 
-import { LayoutMode } from '@/(panel)/notes/page';
+import type { LayoutMode } from '@/(panel)/notes/page';
 
 interface BaseCardProps {
   layout?: LayoutMode;
   accentClassName?: string;
   title: string;
   titleIcon?: ReactNode;
+  typeLabel?: string;
   createdAt?: string;
   updatedAt?: string;
   headerExtra?: ReactNode;
@@ -22,6 +23,7 @@ export function BaseCard({
   accentClassName,
   title,
   titleIcon,
+  typeLabel,
   createdAt,
   updatedAt,
   headerExtra,
@@ -29,60 +31,74 @@ export function BaseCard({
   footerButtons,
 }: BaseCardProps) {
   const lastModified = updatedAt || createdAt;
+  const modifiedLabel = lastModified
+    ? formatDistance(new Date(lastModified), new Date(), { addSuffix: true })
+    : null;
+  const accentClasses = accentClassName
+    ? `border-l-2 ${accentClassName}`
+    : 'border-l-2 border-transparent';
 
   if (layout === 'grid') {
     return (
       <div
-        className={`bg-gray-800 rounded-lg shadow-md overflow-hidden h-full flex flex-col ${accentClassName ? `border-l-4 ${accentClassName}` : ''}`}
+        className={`group h-full overflow-hidden rounded-lg border border-gray-700/80 bg-gray-800/90 shadow-sm transition-colors hover:border-gray-600 ${accentClasses}`}
       >
-        <div className="p-4 border-b border-gray-700 flex items-start">
-          <div className="flex-grow">
-            <div className="flex items-center">
-              {titleIcon}
-              <h3 className="text-xl font-semibold text-red-400 line-clamp-2">{title}</h3>
+        <div className="flex h-full flex-col p-4">
+          <div className="flex min-h-[104px] items-start gap-3">
+            <div className="mt-1 shrink-0 text-red-400">{titleIcon}</div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-start justify-between gap-3">
+                <h3 className="line-clamp-2 text-lg font-semibold leading-snug text-red-300">
+                  {title}
+                </h3>
+                {typeLabel && (
+                  <span className="shrink-0 rounded-md bg-gray-700/80 px-2 py-1 text-[11px] font-medium text-gray-300">
+                    {typeLabel}
+                  </span>
+                )}
+              </div>
+              {modifiedLabel && (
+                <p className="mt-2 text-sm leading-5 text-gray-400">Modified {modifiedLabel}</p>
+              )}
             </div>
-            {lastModified && (
-              <p className="text-sm text-gray-400 mt-1">
-                Last modified{' '}
-                {formatDistance(new Date(lastModified), new Date(), { addSuffix: true })}
-              </p>
-            )}
           </div>
-          {headerExtra}
+          {headerExtra && <div className="mt-3 min-h-[28px]">{headerExtra}</div>}
+          {body && <div className="mt-4 flex-1">{body}</div>}
+          <div className="mt-4 flex flex-wrap justify-end gap-2 border-t border-gray-700/70 pt-3">
+            {footerButtons}
+          </div>
         </div>
-        {body && <div className="p-4 flex-grow">{body}</div>}
-        <div className="p-4 bg-gray-950 flex justify-end gap-2">{footerButtons}</div>
       </div>
     );
   }
 
   return (
     <div
-      className={`bg-gray-800 rounded-lg shadow-md overflow-hidden flex flex-col md:flex-row ${accentClassName ? `border-l-4 ${accentClassName}` : ''}`}
+      className={`group overflow-hidden rounded-lg border border-gray-700/80 bg-gray-800/90 shadow-sm transition-colors hover:border-gray-600 ${accentClasses}`}
     >
-      <div className="p-4 md:w-1/3 border-b md:border-b-0 md:border-r border-gray-700">
-        <div className="flex items-start mb-2 justify-between gap-3">
-          <div className="flex items-center">
-            {titleIcon}
-            <h3 className="text-xl font-semibold text-red-400">{title}</h3>
+      <div className="flex flex-col gap-3 p-4 md:flex-row md:items-center">
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <div className="mt-1 shrink-0 text-red-400">{titleIcon}</div>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+              <h3 className="min-w-0 truncate text-lg font-semibold leading-snug text-red-300">
+                {title}
+              </h3>
+              {typeLabel && (
+                <span className="rounded-md bg-gray-700/80 px-2 py-1 text-[11px] font-medium text-gray-300">
+                  {typeLabel}
+                </span>
+              )}
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-400">
+              {modifiedLabel && <span>Modified {modifiedLabel}</span>}
+            </div>
           </div>
-          {headerExtra}
         </div>
-        {lastModified && (
-          <p className="text-sm text-gray-400">
-            Last modified {formatDistance(new Date(lastModified), new Date(), { addSuffix: true })}
-          </p>
-        )}
-        {createdAt && (
-          <p className="text-sm text-gray-400 mt-1">
-            Created {formatDistance(new Date(createdAt), new Date(), { addSuffix: true })}
-          </p>
-        )}
-      </div>
-
-      <div className="p-4 flex-grow flex flex-col">
-        {body && <div>{body}</div>}
-        <div className={`${body ? 'mt-4' : ''} flex justify-end gap-2`}>{footerButtons}</div>
+        <div className="flex flex-col gap-3 md:items-end">
+          {headerExtra}
+          <div className="flex flex-wrap justify-start gap-2 md:justify-end">{footerButtons}</div>
+        </div>
       </div>
     </div>
   );

--- a/app/components/base-card.tsx
+++ b/app/components/base-card.tsx
@@ -76,28 +76,30 @@ export function BaseCard({
     <div
       className={`group overflow-hidden rounded-lg border border-gray-700/80 bg-gray-800/90 shadow-sm transition-colors hover:border-gray-600 ${accentClasses}`}
     >
-      <div className="flex flex-col gap-3 p-4 md:flex-row md:items-center">
-        <div className="flex min-w-0 flex-1 items-start gap-3">
-          <div className="mt-1 shrink-0 text-red-400">{titleIcon}</div>
-          <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-              <h3 className="min-w-0 truncate text-lg font-semibold leading-snug text-red-300">
+      <div className="flex flex-col gap-2 px-3 py-2 md:flex-row md:items-center">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <div className="shrink-0 text-red-400">{titleIcon}</div>
+          <div className="grid min-w-0 flex-1 gap-1 md:grid-cols-[minmax(12rem,1fr)_auto] md:items-center">
+            <div className="flex min-w-0 items-center gap-2">
+              <h3 className="min-w-0 truncate text-sm font-semibold leading-5 text-red-300">
                 {title}
               </h3>
               {typeLabel && (
-                <span className="rounded-md bg-gray-700/80 px-2 py-1 text-[11px] font-medium text-gray-300">
+                <span className="hidden shrink-0 rounded bg-gray-700/70 px-1.5 py-0.5 text-[10px] font-medium text-gray-300 sm:inline">
                   {typeLabel}
                 </span>
               )}
             </div>
-            <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-400">
+            <div className="flex shrink-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-gray-400 md:justify-end">
               {modifiedLabel && <span>Modified {modifiedLabel}</span>}
             </div>
           </div>
         </div>
-        <div className="flex flex-col gap-3 md:items-end">
+        <div className="flex flex-wrap items-center gap-2 md:shrink-0 md:flex-nowrap">
           {headerExtra}
-          <div className="flex flex-wrap justify-start gap-2 md:justify-end">{footerButtons}</div>
+          <div className="flex flex-wrap justify-start gap-1.5 md:flex-nowrap md:justify-end">
+            {footerButtons}
+          </div>
         </div>
       </div>
     </div>

--- a/app/components/delete-note-button.tsx
+++ b/app/components/delete-note-button.tsx
@@ -40,11 +40,11 @@ export function DeleteNoteButton({ noteId, title }: DeleteNoteButtonProps) {
     <>
       <button
         onClick={handleDeleteClick}
-        className="py-1 px-3 border border-red-700 rounded text-sm text-red-400 hover:bg-red-900/30 transition-colors flex items-center"
+        className="inline-flex h-9 items-center gap-2 rounded-md border border-red-700/90 px-3 text-sm font-medium text-red-300 transition-colors hover:bg-red-950/60 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:opacity-60"
         aria-label="Delete note"
         disabled={isDeleting}
       >
-        <FaTrash className="mr-1" size={12} />
+        <FaTrash size={12} />
         Delete
       </button>
 

--- a/app/components/delete-note-button.tsx
+++ b/app/components/delete-note-button.tsx
@@ -9,9 +9,10 @@ import { deleteNote as deleteNoteAction } from '../(panel)/actions';
 interface DeleteNoteButtonProps {
   noteId: string;
   title: string;
+  dense?: boolean;
 }
 
-export function DeleteNoteButton({ noteId, title }: DeleteNoteButtonProps) {
+export function DeleteNoteButton({ noteId, title, dense = false }: DeleteNoteButtonProps) {
   const [isPending, startTransition] = useTransition();
   const [showConfirm, setShowConfirm] = useState(false);
 
@@ -40,7 +41,9 @@ export function DeleteNoteButton({ noteId, title }: DeleteNoteButtonProps) {
     <>
       <button
         onClick={handleDeleteClick}
-        className="inline-flex h-9 items-center gap-2 rounded-md border border-red-700/90 px-3 text-sm font-medium text-red-300 transition-colors hover:bg-red-950/60 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:opacity-60"
+        className={`inline-flex items-center gap-1.5 rounded-md border border-red-700/90 font-medium text-red-300 transition-colors hover:bg-red-950/60 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:opacity-60 ${
+          dense ? 'h-7 px-2 text-xs' : 'h-9 px-3 text-sm'
+        }`}
         aria-label="Delete note"
         disabled={isDeleting}
       >

--- a/app/components/note-card.tsx
+++ b/app/components/note-card.tsx
@@ -23,15 +23,18 @@ interface NoteCardProps {
   layout?: LayoutMode;
 }
 
-const actionClassName =
-  'inline-flex h-9 items-center gap-2 rounded-md border border-gray-600/90 px-3 text-sm font-medium text-gray-300 transition-colors hover:border-gray-500 hover:bg-gray-700/70 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900';
+const getActionClassName = (layout: LayoutMode) =>
+  `inline-flex items-center gap-1.5 rounded-md border border-gray-600/90 font-medium text-gray-300 transition-colors hover:border-gray-500 hover:bg-gray-700/70 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 ${
+    layout === 'list' ? 'h-7 px-2 text-xs' : 'h-9 px-3 text-sm'
+  }`;
 
 export function NoteCard({ note, layout = 'grid' }: NoteCardProps) {
   const isGoogle = isGoogleNoteMetadata(note);
   const [showJson, setShowJson] = useState(false);
   const metadata = useMemo(() => note, [note]);
   const tags = note.tags || [];
-  const visibleTags = tags.slice(0, layout === 'grid' ? 2 : 3);
+  const actionClassName = getActionClassName(layout);
+  const visibleTags = tags.slice(0, layout === 'grid' ? 2 : 2);
   const hiddenTagCount = Math.max(tags.length - visibleTags.length, 0);
 
   const footerButtons = (
@@ -55,7 +58,7 @@ export function NoteCard({ note, layout = 'grid' }: NoteCardProps) {
         <FaEdit size={12} />
         Edit
       </Link>
-      <DeleteNoteButton noteId={note.id} title={note.title} />
+      <DeleteNoteButton noteId={note.id} title={note.title} dense={layout === 'list'} />
     </>
   );
 
@@ -65,14 +68,22 @@ export function NoteCard({ note, layout = 'grid' }: NoteCardProps) {
         {visibleTags.map((tag) => (
           <span
             key={tag}
-            className="max-w-[10rem] truncate rounded-md bg-gray-700/80 px-2 py-1 text-[11px] font-medium text-gray-300"
+            className={`truncate rounded bg-gray-700/80 font-medium text-gray-300 ${
+              layout === 'list'
+                ? 'max-w-[7rem] px-1.5 py-0.5 text-[10px]'
+                : 'max-w-[10rem] px-2 py-1 text-[11px]'
+            }`}
             title={tag}
           >
             {tag}
           </span>
         ))}
         {hiddenTagCount > 0 && (
-          <span className="rounded-md bg-gray-700/60 px-2 py-1 text-[11px] font-medium text-gray-400">
+          <span
+            className={`rounded bg-gray-700/60 font-medium text-gray-400 ${
+              layout === 'list' ? 'px-1.5 py-0.5 text-[10px]' : 'px-2 py-1 text-[11px]'
+            }`}
+          >
             +{hiddenTagCount}
           </span>
         )}
@@ -80,11 +91,13 @@ export function NoteCard({ note, layout = 'grid' }: NoteCardProps) {
       {tags.length === 0 && <span className="text-xs text-gray-500">No tags</span>}
       <button
         onClick={() => setShowJson(true)}
-        className="ml-auto inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-gray-600/90 px-2 text-xs font-medium text-gray-300 transition-colors hover:border-gray-500 hover:bg-gray-700/70 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900"
+        className={`ml-auto inline-flex shrink-0 items-center gap-1.5 rounded-md border border-gray-600/90 font-medium text-gray-300 transition-colors hover:border-gray-500 hover:bg-gray-700/70 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 ${
+          layout === 'list' ? 'h-7 px-1.5 text-xs' : 'h-7 px-2 text-xs'
+        }`}
         title="View metadata JSON"
       >
         <FaInfoCircle size={12} />
-        <span className="sr-only sm:not-sr-only">JSON</span>
+        <span className={layout === 'list' ? 'sr-only' : 'sr-only sm:not-sr-only'}>JSON</span>
       </button>
     </div>
   );
@@ -95,7 +108,11 @@ export function NoteCard({ note, layout = 'grid' }: NoteCardProps) {
         layout={layout}
         title={note.title}
         titleIcon={
-          isGoogle ? <FaGoogle size={18} aria-hidden /> : <FaFileAlt size={18} aria-hidden />
+          isGoogle ? (
+            <FaGoogle size={layout === 'list' ? 14 : 18} aria-hidden />
+          ) : (
+            <FaFileAlt size={layout === 'list' ? 14 : 18} aria-hidden />
+          )
         }
         typeLabel={isGoogle ? 'Google Doc' : 'Note'}
         createdAt={note.createdAt}

--- a/app/components/note-card.tsx
+++ b/app/components/note-card.tsx
@@ -119,7 +119,6 @@ export function NoteCard({ note, layout = 'grid' }: NoteCardProps) {
         updatedAt={note.updatedAt}
         headerExtra={headerExtra}
         footerButtons={footerButtons}
-        accentClassName={isGoogle ? 'border-red-500' : undefined}
       />
       <JsonModal
         open={showJson}

--- a/app/components/note-card.tsx
+++ b/app/components/note-card.tsx
@@ -11,21 +11,28 @@ import {
   FaInfoCircle,
 } from 'react-icons/fa';
 import { isGoogleNoteMetadata, NoteMetadata } from 'tt-services/src/client-index';
-type LayoutMode = 'grid' | 'list';
+
 import { BaseCard } from './base-card';
 import { DeleteNoteButton } from './delete-note-button';
 import { JsonModal } from './json-modal';
-import { NoteTagManager } from './note-tag-manager';
+
+type LayoutMode = 'grid' | 'list';
 
 interface NoteCardProps {
   note: NoteMetadata;
   layout?: LayoutMode;
 }
 
+const actionClassName =
+  'inline-flex h-9 items-center gap-2 rounded-md border border-gray-600/90 px-3 text-sm font-medium text-gray-300 transition-colors hover:border-gray-500 hover:bg-gray-700/70 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900';
+
 export function NoteCard({ note, layout = 'grid' }: NoteCardProps) {
   const isGoogle = isGoogleNoteMetadata(note);
   const [showJson, setShowJson] = useState(false);
   const metadata = useMemo(() => note, [note]);
+  const tags = note.tags || [];
+  const visibleTags = tags.slice(0, layout === 'grid' ? 2 : 3);
+  const hiddenTagCount = Math.max(tags.length - visibleTags.length, 0);
 
   const footerButtons = (
     <>
@@ -34,24 +41,18 @@ export function NoteCard({ note, layout = 'grid' }: NoteCardProps) {
           href={`https://docs.google.com/document/d/${note.googleDocId}/edit`}
           target="_blank"
           rel="noreferrer"
-          className="py-1 px-3 border border-gray-600 rounded text-sm text-gray-300 hover:bg-gray-800 transition-colors flex items-center"
+          className={actionClassName}
         >
-          <FaExternalLinkAlt className="mr-1" size={12} />
-          Open Google Doc
+          <FaExternalLinkAlt size={12} />
+          Open
         </a>
       )}
-      <Link
-        href={`/note/${note.id}/view`}
-        className="py-1 px-3 border border-gray-600 rounded text-sm text-gray-300 hover:bg-gray-800 transition-colors flex items-center"
-      >
-        <FaEye className="mr-1" size={12} />
+      <Link href={`/note/${note.id}/view`} className={actionClassName}>
+        <FaEye size={12} />
         View
       </Link>
-      <Link
-        href={`/note/${note.id}/edit`}
-        className="py-1 px-3 border border-gray-600 rounded text-sm text-gray-300 hover:bg-gray-800 transition-colors flex items-center"
-      >
-        <FaEdit className="mr-1" size={12} />
+      <Link href={`/note/${note.id}/edit`} className={actionClassName}>
+        <FaEdit size={12} />
         Edit
       </Link>
       <DeleteNoteButton noteId={note.id} title={note.title} />
@@ -59,19 +60,31 @@ export function NoteCard({ note, layout = 'grid' }: NoteCardProps) {
   );
 
   const headerExtra = (
-    <div className="flex items-center gap-2 flex-wrap">
-      {(note.tags || []).map((tag) => (
-        <span key={tag} className="px-2 py-0.5 bg-gray-700 text-gray-300 text-xs rounded-full">
-          {tag}
-        </span>
-      ))}
-      {(note.tags || []).length === 0 && <span className="text-xs text-gray-500">No tags</span>}
+    <div className="flex max-w-full items-center gap-2">
+      <div className="flex min-w-0 flex-wrap gap-1.5">
+        {visibleTags.map((tag) => (
+          <span
+            key={tag}
+            className="max-w-[10rem] truncate rounded-md bg-gray-700/80 px-2 py-1 text-[11px] font-medium text-gray-300"
+            title={tag}
+          >
+            {tag}
+          </span>
+        ))}
+        {hiddenTagCount > 0 && (
+          <span className="rounded-md bg-gray-700/60 px-2 py-1 text-[11px] font-medium text-gray-400">
+            +{hiddenTagCount}
+          </span>
+        )}
+      </div>
+      {tags.length === 0 && <span className="text-xs text-gray-500">No tags</span>}
       <button
         onClick={() => setShowJson(true)}
-        className="py-1 px-2 border border-gray-600 rounded text-xs text-gray-300 hover:bg-gray-800 transition-colors flex items-center"
+        className="ml-auto inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-gray-600/90 px-2 text-xs font-medium text-gray-300 transition-colors hover:border-gray-500 hover:bg-gray-700/70 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900"
         title="View metadata JSON"
       >
-        <FaInfoCircle className="mr-1" size={12} /> JSON
+        <FaInfoCircle size={12} />
+        <span className="sr-only sm:not-sr-only">JSON</span>
       </button>
     </div>
   );
@@ -82,12 +95,9 @@ export function NoteCard({ note, layout = 'grid' }: NoteCardProps) {
         layout={layout}
         title={note.title}
         titleIcon={
-          isGoogle ? (
-            <FaGoogle className="text-red-400 mr-2" size={18} />
-          ) : (
-            <FaFileAlt className="text-red-400 mr-2" size={18} />
-          )
+          isGoogle ? <FaGoogle size={18} aria-hidden /> : <FaFileAlt size={18} aria-hidden />
         }
+        typeLabel={isGoogle ? 'Google Doc' : 'Note'}
         createdAt={note.createdAt}
         updatedAt={note.updatedAt}
         headerExtra={headerExtra}

--- a/app/components/untrack-google-doc-card.tsx
+++ b/app/components/untrack-google-doc-card.tsx
@@ -5,15 +5,19 @@ import React, { useMemo, useState } from 'react';
 import { FaCheck, FaExternalLinkAlt, FaGoogle, FaInfoCircle, FaSync } from 'react-icons/fa';
 
 import { trackGoogleDoc } from '../google/docs/actions';
-type LayoutMode = 'grid' | 'list';
 import type { GoogleDriveFile } from '../types/google';
 import { BaseCard } from './base-card';
 import { JsonModal } from './json-modal';
+
+type LayoutMode = 'grid' | 'list';
 
 interface UntrackedGoogleDocCardProps {
   doc: GoogleDriveFile;
   layout?: LayoutMode;
 }
+
+const actionClassName =
+  'inline-flex h-9 items-center gap-2 rounded-md border border-gray-600/90 px-3 text-sm font-medium text-gray-300 transition-colors hover:border-gray-500 hover:bg-gray-700/70 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:opacity-60';
 
 export function UntrackedGoogleDocCard({ doc, layout = 'grid' }: UntrackedGoogleDocCardProps) {
   const router = useRouter();
@@ -52,39 +56,39 @@ export function UntrackedGoogleDocCard({ doc, layout = 'grid' }: UntrackedGoogle
 
   const openButton = (
     <button
-      className="py-1 px-3 border border-gray-600 rounded text-sm text-gray-300 hover:bg-gray-800 transition-colors flex items-center"
+      className={actionClassName}
       onClick={() => webViewLink && window.open(webViewLink, '_blank')}
       disabled={!webViewLink}
       title="Open Google Doc"
     >
-      <FaExternalLinkAlt className="mr-1" size={12} />
+      <FaExternalLinkAlt size={12} />
       Open
     </button>
   );
 
   const syncButton = (
     <button
-      className={`py-1 px-3 rounded text-sm flex items-center border ${
+      className={`inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:opacity-60 ${
         isTracking
-          ? 'text-gray-400 border-gray-600 hover:bg-gray-800'
-          : 'text-white border-blue-600 hover:bg-blue-900'
+          ? 'border-gray-600/90 text-gray-400 hover:bg-gray-700/70'
+          : 'border-blue-500 text-white hover:bg-blue-950/70'
       }`}
       onClick={handleSync}
       disabled={syncing || isTracking}
     >
       {syncing ? (
         <>
-          <span className="mr-1 h-3 w-3 inline-block rounded-full border-t-2 border-gray-500 animate-spin"></span>
+          <span className="inline-block h-3 w-3 rounded-full border-t-2 border-gray-500 animate-spin"></span>
           Syncing...
         </>
       ) : isTracking ? (
         <>
-          <FaCheck className="mr-1" size={12} />
+          <FaCheck size={12} />
           Synced
         </>
       ) : (
         <>
-          <FaSync className="mr-1" size={12} />
+          <FaSync size={12} />
           Sync
         </>
       )}
@@ -93,13 +97,13 @@ export function UntrackedGoogleDocCard({ doc, layout = 'grid' }: UntrackedGoogle
 
   const headerExtra = (
     <div className="flex items-center gap-2">
-      <span className="px-2 py-1 bg-gray-700 rounded text-xs">Google Doc</span>
       <button
         onClick={() => setShowJson(true)}
-        className="py-1 px-2 border border-gray-600 rounded text-xs text-gray-300 hover:bg-gray-800 transition-colors flex items-center"
+        className="inline-flex h-7 items-center gap-1.5 rounded-md border border-gray-600/90 px-2 text-xs font-medium text-gray-300 transition-colors hover:border-gray-500 hover:bg-gray-700/70 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900"
         title="View metadata JSON"
       >
-        <FaInfoCircle className="mr-1" size={12} /> JSON
+        <FaInfoCircle size={12} />
+        <span className="sr-only sm:not-sr-only">JSON</span>
       </button>
     </div>
   );
@@ -109,7 +113,8 @@ export function UntrackedGoogleDocCard({ doc, layout = 'grid' }: UntrackedGoogle
       <BaseCard
         layout={layout}
         title={name}
-        titleIcon={<FaGoogle className="text-red-400 mr-2" size={18} />}
+        titleIcon={<FaGoogle size={18} aria-hidden />}
+        typeLabel="Google Doc"
         createdAt={createdTime ?? undefined}
         updatedAt={modifiedTime ?? undefined}
         headerExtra={headerExtra}

--- a/app/components/untrack-google-doc-card.tsx
+++ b/app/components/untrack-google-doc-card.tsx
@@ -129,7 +129,6 @@ export function UntrackedGoogleDocCard({ doc, layout = 'grid' }: UntrackedGoogle
             {syncButton}
           </>
         }
-        accentClassName={'border-red-500'}
       />
       <JsonModal
         open={showJson}

--- a/app/components/untrack-google-doc-card.tsx
+++ b/app/components/untrack-google-doc-card.tsx
@@ -16,8 +16,10 @@ interface UntrackedGoogleDocCardProps {
   layout?: LayoutMode;
 }
 
-const actionClassName =
-  'inline-flex h-9 items-center gap-2 rounded-md border border-gray-600/90 px-3 text-sm font-medium text-gray-300 transition-colors hover:border-gray-500 hover:bg-gray-700/70 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:opacity-60';
+const getActionClassName = (layout: LayoutMode) =>
+  `inline-flex items-center gap-1.5 rounded-md border border-gray-600/90 font-medium text-gray-300 transition-colors hover:border-gray-500 hover:bg-gray-700/70 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:opacity-60 ${
+    layout === 'list' ? 'h-7 px-2 text-xs' : 'h-9 px-3 text-sm'
+  }`;
 
 export function UntrackedGoogleDocCard({ doc, layout = 'grid' }: UntrackedGoogleDocCardProps) {
   const router = useRouter();
@@ -32,6 +34,7 @@ export function UntrackedGoogleDocCard({ doc, layout = 'grid' }: UntrackedGoogle
   const webViewLink = doc.webViewLink ?? '';
   const createdTime = doc.createdTime ?? '';
   const modifiedTime = doc.modifiedTime ?? '';
+  const actionClassName = getActionClassName(layout);
 
   const handleSync = async () => {
     setSyncing(true);
@@ -68,7 +71,9 @@ export function UntrackedGoogleDocCard({ doc, layout = 'grid' }: UntrackedGoogle
 
   const syncButton = (
     <button
-      className={`inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:opacity-60 ${
+      className={`inline-flex items-center gap-1.5 rounded-md border font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 disabled:cursor-not-allowed disabled:opacity-60 ${
+        layout === 'list' ? 'h-7 px-2 text-xs' : 'h-9 px-3 text-sm'
+      } ${
         isTracking
           ? 'border-gray-600/90 text-gray-400 hover:bg-gray-700/70'
           : 'border-blue-500 text-white hover:bg-blue-950/70'
@@ -99,11 +104,11 @@ export function UntrackedGoogleDocCard({ doc, layout = 'grid' }: UntrackedGoogle
     <div className="flex items-center gap-2">
       <button
         onClick={() => setShowJson(true)}
-        className="inline-flex h-7 items-center gap-1.5 rounded-md border border-gray-600/90 px-2 text-xs font-medium text-gray-300 transition-colors hover:border-gray-500 hover:bg-gray-700/70 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900"
+        className="inline-flex h-7 items-center gap-1.5 rounded-md border border-gray-600/90 px-1.5 text-xs font-medium text-gray-300 transition-colors hover:border-gray-500 hover:bg-gray-700/70 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900"
         title="View metadata JSON"
       >
         <FaInfoCircle size={12} />
-        <span className="sr-only sm:not-sr-only">JSON</span>
+        <span className={layout === 'list' ? 'sr-only' : 'sr-only sm:not-sr-only'}>JSON</span>
       </button>
     </div>
   );
@@ -113,7 +118,7 @@ export function UntrackedGoogleDocCard({ doc, layout = 'grid' }: UntrackedGoogle
       <BaseCard
         layout={layout}
         title={name}
-        titleIcon={<FaGoogle size={18} aria-hidden />}
+        titleIcon={<FaGoogle size={layout === 'list' ? 14 : 18} aria-hidden />}
         typeLabel="Google Doc"
         createdAt={createdTime ?? undefined}
         updatedAt={modifiedTime ?? undefined}


### PR DESCRIPTION
## Summary

- Restyles note and Google Doc cards with a denser shared layout for grid and list views.
- Defaults Notes to list view.
- Makes list view significantly more compact with smaller rows, tighter spacing, smaller controls, and inline metadata/actions.
- Removes the red outline/accent from Google note cards.
- Adds visible keyboard shortcuts plus arrow-key selection and Enter-to-open behavior for notes.
- Tightens action button styling, tag display, metadata placement, and focus states.
- Loads Mongo-backed note metadata even when there is no Google session, so local auth bypass still shows regular notes.

## Validation

- bun run typecheck
- bun run lint
- Local /notes server-action requests return 200 with Mongo connected and no Google session.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly client UI and styling; the server-action fallback only broadens note listing when Google is disconnected and still requires auth.
> 
> **Overview**
> **Improves the `/notes` experience** with a denser card layout (especially list view), visible shortcut hints, and full keyboard control: `/` focuses search, arrows move selection, Enter opens (note view vs Google Doc in a new tab), `V` toggles grid/list, and `N` creates a note. List is now the default; selected rows get a focus ring and scroll into view.
> 
> **Shared card components** (`BaseCard`, note/Google doc cards, delete button) are restyled with tighter spacing, smaller list actions, truncated tags with a `+N` overflow, optional type badges, and no red left accent on Google items.
> 
> **Data loading:** when there is no Google session, `getNotesAndUntrackedGoogleDocs` still returns Mongo note metadata (empty untracked docs) instead of an empty notes list, while `showGoogleNotice` stays unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dbe49fcc4d25eeadd29d83a0637d2b7a5999a43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->